### PR TITLE
Fix tests for a different error message from Redis

### DIFF
--- a/t/03-auth.t
+++ b/t/03-auth.t
@@ -95,7 +95,7 @@ sub t_invalid_password {
       "$t_name_prefix; command error message" );
   is( $t_cmd_err->code, E_OPRN_ERROR, "$t_name_prefix; command error code" );
   isa_ok( $t_cli_err, 'AnyEvent::RipeRedis::Error' );
-  like( $t_cli_err->message, qr/^ERR invalid password/,
+  like( $t_cli_err->message, qr/^(?:ERR invalid password|WRONGPASS )/,
       "$t_name_prefix; client error message" );
   is( $t_cli_err->code, E_OPRN_ERROR, "$t_name_prefix; client error code" );
 


### PR DESCRIPTION
I tried to compile AnyEvent::RipeRedis on Fedora 34 with redis-6.2.3-1.fc34.x86_64 installed, but t/03-auth.t failed. It seems that my version of Redis returns different error message than the test expects. I am adding the error message as an alternative.